### PR TITLE
Mutexes are now recursive to allow locking again in same thread

### DIFF
--- a/src/osip2/port_sema.c
+++ b/src/osip2/port_sema.c
@@ -43,7 +43,12 @@ osip_mutex_init ()
 
   if (mut == NULL)
     return NULL;
-  pthread_mutex_init (mut, NULL);
+
+  pthread_mutexattr_t attr;
+  pthread_mutexattr_init (&attr);
+  pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_RECURSIVE);
+
+  pthread_mutex_init (mut, &attr);
   return (struct osip_mutex *) mut;
 }
 


### PR DESCRIPTION
For fixing https://textnow.atlassian.net/browse/CALLING-1589, which appears to be a caused by code that triggers OSIP to lock the same mutex twice in the same thread, given the stacktraces that have been seen in Embrace: https://dash.embrace.io/app/DiFBd/v/22.5.0.0/session/day/crash/eyJvcyI6ImEiLCJvc192YXJpYW50IjoiIiwiZnJhbWV3b3JrIjoxLCJnaWQiOiIyNUUwNTk5MzBGMkU1REE4QTlERTQzMkZGQkJDMTI3MyIsImJpZCI6IjBCQzM3MDcxRDAwMzQ0MDNBNjY2QkEwRDZDQTMxREU3IiwibSI6Im9zaXBfZmlmb19hZGQiLCJmaWxlIjoiL2xpYi9hcm0vbGliamluZ2xlX3BlZXJjb25uZWN0aW9uX3NvLnNvIiwibW8iOjM1NjY0NTcsImIiOiIiLCJuZGsiOnRydWUsIm1hIjoxODExNDY4Mjg4fQ==?tab=stack_trace

Note that the crash above is a SIGABRT which most commonly happens in that scenario I described.

But this is also generally useful to allow more flexible locking/events.